### PR TITLE
chore: make main deployable — pin sklearn, load model once, harden startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,22 +3,21 @@ FROM continuumio/miniconda3:latest
 WORKDIR /app
 
 # Copy environment file and create conda env
-COPY environment-no-builds.yml .
-RUN conda env create -f environment-no-builds.yml
+COPY environment.yml .
+RUN conda env create -f environment.yml
 
 # Activate environment and ensure it's used
 SHELL ["conda", "run", "-n", "YT-Validator", "/bin/bash", "-c"]
 
-# Copy application files
-COPY app.py pipeline.py ./
-COPY data ./data/
+# Application code, plus the artifacts pipeline.py resolves next to itself
+COPY app.py pipeline.py helpers.py ./
+COPY model.joblib Licensed.csv assets_single_media_component.csv ./
 
-# Create data directory for runtime
+# Runtime scratch: uploads, outputs and the task store live here
 RUN mkdir -p /app/data
 
-# Set environment variables
 ENV FLASK_RUN_HOST=0.0.0.0
 ENV FLASK_DEBUG=0
+EXPOSE 3001
 
-# Cloud Run requires the app to listen on $PORT
-CMD ["conda", "run", "-n", "YT-Validator", "python", "app.py"]
+CMD ["conda", "run", "--no-capture-output", "-n", "YT-Validator", "python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -19,6 +19,20 @@ app = Flask(__name__)
 tasks = TaskStore()
 GIT_BRANCH, GIT_COMMIT = get_git_info()
 
+# One scoring run saturates the available cores, so runs are serialised.
+# Concurrent runs would only contend for CPU while multiplying peak memory.
+INFERENCE_SLOT = threading.Semaphore(1)
+
+# Warm the model at import (Gunicorn imports this module), so a corrupt artifact
+# fails the service at startup rather than inside a background task. A missing
+# artifact is a valid state -- /predict can still be called with training_data.
+from pipeline import model_info, warm_model
+
+try:
+    print(f"Model warm in {warm_model():.2f}s")
+except FileNotFoundError:
+    print("No model artifact yet -- /predict needs training_data to build one")
+
 
 @app.route('/health')
 def health_check():
@@ -28,6 +42,8 @@ def health_check():
         'version': '1.0.0',
         'branch': GIT_BRANCH,
         'commit': GIT_COMMIT,
+        'model': model_info(),
+        'running_tasks': sum(1 for t in tasks.values() if t.get('status') == 'running'),
         'timestamp': time.time()
     })
 
@@ -140,7 +156,8 @@ def run_prediction(task_id, args):
     try:
         
         from pipeline import main
-        main(args, status_callback=update_status, stop_check=should_stop)
+        with INFERENCE_SLOT:                      # one scoring run at a time
+            main(args, status_callback=update_status, stop_check=should_stop)
 
         if should_stop():
             tasks[task_id]['status'] = 'stopped'

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - scikit-learn>=1.3
+  - scikit-learn>=1.9
   - google-api-python-client
   - pandas
   - numpy

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,5 +1,8 @@
 import argparse
 import os
+import sys
+import threading
+import time
 import warnings
 from datetime import datetime
 from pathlib import Path
@@ -29,6 +32,83 @@ TRAIN_START = pandas.Timestamp('2022-01-01')  # recency window that validated be
 HOLDOUT_DAYS = 150          # most recent labeled claims, used to tune thresholds
 BUCKET_TARGET = 0.95        # per-bucket accuracy target for triage cutoffs
 MIN_BUCKET_N = 50
+
+# The artifact is deserialised once per process rather than once per request, and
+# app.py warms it at startup so a corrupt model fails the service immediately
+# instead of surfacing inside a background task.
+_ARTIFACT = None
+_MODEL_LOAD_SECONDS = None
+_WARM_SECONDS = None
+_LOAD_LOCK = threading.Lock()
+
+# One row exercising every raw column build_features() reads, so warming runs the
+# real encode + predict path rather than just touching the file.
+_WARM_PROBE = {
+    'views': 1, 'matching_duration': 60.0, 'longest_match': 60.0,
+    'video_duration_sec': 60.0, 'video_title': 'warmup',
+    'claim_created_date': '2026-01-02', 'video_upload_date': '2026-01-01',
+    'claim_type': 'AUDIOVISUAL', 'claim_origin': 'UGC', 'content_type': 'VIDEO_MATCH',
+    'claim_report_source': 'warmup', 'asset_labels': 'warmup',
+    'asset_id': 'warmup', 'custom_id': 'warmup',
+    'reference_id': 'warmup', 'channel_id': 'warmup',
+}
+
+
+def peak_rss_mb():
+    """Process high-water memory mark, in MB. ru_maxrss is bytes on macOS, KB on Linux."""
+    try:
+        import resource
+        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return round(peak / (1048576 if sys.platform == 'darwin' else 1024), 1)
+    except Exception:
+        return None
+
+
+def get_artifact():
+    """Return the model artifact, deserialising it once per process."""
+    global _ARTIFACT, _MODEL_LOAD_SECONDS
+    if _ARTIFACT is None:
+        with _LOAD_LOCK:
+            if _ARTIFACT is None:  # another thread may have won the race
+                started = time.time()
+                artifact = joblib.load(MODEL_PATH)
+                _MODEL_LOAD_SECONDS = time.time() - started
+                _ARTIFACT = artifact
+    return _ARTIFACT
+
+
+def warm_model():
+    """Load the artifact and score one row, so a corrupt model fails loudly here.
+
+    Raises FileNotFoundError when no artifact exists yet -- that is a valid
+    state, since /predict can still be called with training_data to build one.
+    """
+    global _WARM_SECONDS
+    artifact = get_artifact()
+    started = time.time()
+    artifact['model'].predict_proba(build_features(pandas.DataFrame([_WARM_PROBE]))[FEATURES])
+    _WARM_SECONDS = time.time() - started
+    return _WARM_SECONDS
+
+
+def model_info():
+    """Describe the loaded model, for /health and deploy verification."""
+    meta = (_ARTIFACT or {}).get('metadata', {})
+    return {
+        'model_path': str(MODEL_PATH),
+        'loaded': _ARTIFACT is not None,
+        'warm': _WARM_SECONDS is not None,
+        'threshold': (_ARTIFACT or {}).get('threshold'),
+        't_low': (_ARTIFACT or {}).get('t_low'),
+        't_high': (_ARTIFACT or {}).get('t_high'),
+        'trained_at': meta.get('trained_at'),
+        'train_rows': meta.get('train_rows'),
+        'holdout_auc': meta.get('holdout_auc'),
+        'load_seconds': round(_MODEL_LOAD_SECONDS, 2) if _MODEL_LOAD_SECONDS else None,
+        'warm_seconds': round(_WARM_SECONDS, 2) if _WARM_SECONDS else None,
+        'peak_rss_mb': peak_rss_mb(),
+    }
+
 
 # Claims with these no_codes are excluded from training: their verdicts are
 # rule-driven (licensed asset, video unavailable, ...) and are reproduced by
@@ -189,6 +269,8 @@ def train_model(training_data, status_callback=None, check_stopped=None):
         },
     }
     joblib.dump(artifact, MODEL_PATH)
+    global _ARTIFACT
+    _ARTIFACT = artifact          # a retrain replaces what the process serves
     status(f'Saved model artifact to {MODEL_PATH}')
     return artifact
 
@@ -253,7 +335,7 @@ def main(args, status_callback=None, stop_check=None):
     if MODEL_PATH.exists():
         if status_callback:
             status_callback(f'Loading cached model from {MODEL_PATH}')
-        artifact = joblib.load(MODEL_PATH)
+        artifact = get_artifact()
     else:
         if not args.training_data:
             raise ValueError(f'Training data is required to create {MODEL_PATH}')


### PR DESCRIPTION
Makes `main` safe to deploy. No change to predictions.

- **Pin `scikit-learn>=1.9`** — `model.joblib` was pickled under 1.9.0, the VM has
  1.8.0, and loading it there warns "may lead to invalid results". Verified 1.9.0
  py311 resolves on linux-64.
- **Load the model once per process** — `main()` re-read the artifact on every run.
- **Warm at startup** — a corrupt artifact now fails the service at boot, not inside
  a background task. A missing artifact still works (`/predict` can train one).
- **Serialise runs** — one scoring run already saturates the cores.
- **`/health` is deploy-verifiable** — thresholds, `trained_at`, `holdout_auc`,
  load/warm timings, RSS, running tasks.
- **Fix the Dockerfile** — it referenced `environment-no-builds.yml`, which doesn't
  exist, so the build could never succeed; also copies the runtime files it was
  missing.

Verified at sklearn 1.9: warm 0.07s, `/health` 200, end-to-end run on July's export
(4,538 rows) and the missing-artifact path.

Pre-existing issues left for separate PRs: an API error marks all 50 videos in a
batch unavailable (which force-rejects them), and `excluded_codes` drops `X`/`N`
from training with no rule reproducing them at predict time.